### PR TITLE
Relative path fix

### DIFF
--- a/save_as_proxy.py
+++ b/save_as_proxy.py
@@ -41,7 +41,7 @@ class ProxyFileSave(bpy.types.Operator):
             outpath_final = os.path.dirname(bpy.path.abspath(bpy.data.filepath))
             print(os.path.join(outpath, outname))
             report = bpy.ops.wm.save_as_mainfile(filepath=os.path.join(outpath, outname),
-                        check_existing=True, copy=True)
+                        check_existing=True, copy=True, relative_remap=False)
                         
             # os.rename(os.path.join(outpath, outname), os.path.join(outpath_final, outname)) # Does not work accross devices
             if report == {"FINISHED"}:


### PR DESCRIPTION
Disabled the relative_remap flag, which while True converts all paths to absolute while saving the blend file to another location. Another location in this case being the temporary folder that the addon uses before copying the file to its original location in post.
Per issue - https://github.com/woutervddn/blender_addon_save_by_proxy/issues/1